### PR TITLE
Improve error message for PHP if API call fails

### DIFF
--- a/swagger-templates/php/ApiClient.mustache
+++ b/swagger-templates/php/ApiClient.mustache
@@ -233,7 +233,16 @@ class ApiClient
 
         // Handle the response
         if ($response_info['http_code'] == 0) {
-            throw new ApiException("API call to $url timed out: ".serialize($response_info), 0, null, null);
+            $curl_error_message = curl_error($curl);
+
+            // curl_exec can sometimes fail but still return a blank message from curl_error().
+            if (!empty($curl_error_message)) {
+                $error_message = "API call to $url failed: " . curl_error($curl);
+            } else {
+                $error_message = "API call to $url failed, but for an unknown reason. " .
+                    "This could happen if you are disconnected from the network.";
+            }
+            throw new ApiException($error_message, 0, null, null);
         } elseif ($response_info['http_code'] >= 200 && $response_info['http_code'] <= 299 ) {
             // return raw body if response is a file
             if ($responseType == '\SplFileObject' || $responseType == 'ByteArray') {


### PR DESCRIPTION
Previous ApiException message would simply print out the result of the `curl_getinfo($curl)` call, which might be useful only if the developer actually wanted very low-level information from curl about why a call
failed. The new message should print out a higher-level but more informative, human-readable message.

Reviewers: @StephenBarlow 
CC: @da3mon