### PR TITLE
make the user agent easier to parse by having a slash instead of hyphen version

### DIFF
--- a/swagger-templates/ruby/api_client.mustache
+++ b/swagger-templates/ruby/api_client.mustache
@@ -21,7 +21,7 @@ module {{moduleName}}
 
     def initialize(config = Configuration.default)
       @config = config
-      @user_agent = "square-connect-ruby-#{VERSION}"
+      @user_agent = "square-connect-ruby/#{VERSION}"
       @default_headers = {
         'Content-Type' => "application/json",
         'Accept' => "application/json",


### PR DESCRIPTION
@StephenBarlow 