### PR TITLE
importPath no longer works for models

### DIFF
--- a/swagger-templates/ruby/gem.mustache
+++ b/swagger-templates/ruby/gem.mustache
@@ -10,7 +10,9 @@ require '{{gemName}}/configuration'
 
 # Models
 {{#models}}
-require '{{importPath}}'
+{{#model}}
+require '{{gemName}}/{{modelPackage}}/{{classFilename}}'
+{{/model}}
 {{/models}}
 
 # APIs


### PR DESCRIPTION
reverted to the current gem.mustache on swagger-codegen master:
https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/resources/ruby/gem.mustache