### PR TITLE
add version badges for all but PHP (which didn't work)

### DIFF
--- a/swagger-templates/csharp/README.mustache
+++ b/swagger-templates/csharp/README.mustache
@@ -1,4 +1,4 @@
-# Square Connect V2 C# SDK [![Build Status](https://travis-ci.org/square/connect-csharp-sdk.svg?branch=master)](https://travis-ci.org/square/connect-csharp-sdk)
+# Square Connect V2 C# SDK [![Build Status](https://travis-ci.org/square/connect-csharp-sdk.svg?branch=master)](https://travis-ci.org/square/connect-csharp-sdk)[![NuGet version](https://badge.fury.io/nu/Square.Connect.svg)](https://badge.fury.io/nu/Square.Connect)
 
 This repository contains the released C# client SDK. Check out our [API
 specification repository](https://github.com/square/connect-api-specification)

--- a/swagger-templates/python/README.mustache
+++ b/swagger-templates/python/README.mustache
@@ -1,4 +1,4 @@
-# Square Connect V2 Python SDK [![Build Status](https://travis-ci.org/square/connect-python-sdk.svg?branch=master)](https://travis-ci.org/square/connect-python-sdk)
+# Square Connect V2 Python SDK [![Build Status](https://travis-ci.org/square/connect-python-sdk.svg?branch=master)](https://travis-ci.org/square/connect-python-sdk)[![PyPI version](https://badge.fury.io/py/squareconnect.svg)](https://badge.fury.io/py/squareconnect)
 
 This repository contains the released Python client SDK. Check out our [API
 specification repository](https://github.com/square/connect-api-specification)

--- a/swagger-templates/ruby/README.mustache
+++ b/swagger-templates/ruby/README.mustache
@@ -1,4 +1,4 @@
-Connect v2 Ruby SDKs [![Build Status](https://travis-ci.org/square/connect-ruby-sdk.svg?branch=master)](https://travis-ci.org/square/connect-ruby-sdk)
+Connect v2 Ruby SDKs [![Build Status](https://travis-ci.org/square/connect-ruby-sdk.svg?branch=master)](https://travis-ci.org/square/connect-ruby-sdk)[![Gem Version](https://badge.fury.io/rb/square_connect.svg)](https://badge.fury.io/rb/square_connect)
 ===============
 
 This repository contains the released Ruby client SDK. Check out our [API


### PR DESCRIPTION
I read that they were a good thing to have, so I'm willing to give them a shot. 

I sent an email about https://badge.fury.io/for/ph/square/connect

Since this 'badge section' is already a template fork, I don't think it will be much of an additional maintenance burden.  