### PR TITLE
add commit messages to repo level commits

### DIFF
--- a/travis-ci/push-csharp-sdk.sh
+++ b/travis-ci/push-csharp-sdk.sh
@@ -34,7 +34,7 @@ cp ../swagger-out/csharp/build.sh .
 cp ../swagger-out/csharp/mono_nunit_test.sh .
 
 git add .
-git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT}"
+git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT} | ${TRAVIS_COMMIT_MESSAGE}"
 
 # only push to sdk repo when it's merged into master
 if [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "" -a "${TRAVIS_BRANCH}" = "master" ];

--- a/travis-ci/push-php-sdk.sh
+++ b/travis-ci/push-php-sdk.sh
@@ -31,7 +31,7 @@ cp ../swagger-out/php/SquareConnect/composer.json .
 cp ../swagger-out/php/SquareConnect/README.md .
 
 git add .
-git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT}"
+git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT} | ${TRAVIS_COMMIT_MESSAGE}"
 
 # only push to sdk repo when it's merged into master
 if [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "" -a "${TRAVIS_BRANCH}" = "master" ];

--- a/travis-ci/push-python-sdk.sh
+++ b/travis-ci/push-python-sdk.sh
@@ -32,7 +32,7 @@ cp ../swagger-out/python/tox.ini .
 cp ../swagger-out/python/README.md .
 
 git add .
-git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT}"
+git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT} | ${TRAVIS_COMMIT_MESSAGE}"
 
 # only push to sdk repo when it's merged into master
 if [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "" -a "${TRAVIS_BRANCH}" = "master" ];

--- a/travis-ci/push-python-sdk.sh
+++ b/travis-ci/push-python-sdk.sh
@@ -4,7 +4,6 @@ set -e
 
 DIR=$(dirname "$0")
 packageVersion=$( cat ./swagger-config/config-python.json | jq -r ".packageVersion" )
-BRANCH_NAME=release/$packageVersion
 
 echo "Going to update Python SDK..."
 
@@ -14,7 +13,15 @@ ssh-add $DIR/python-repo.pem
 
 git clone git@github.com:square/connect-python-sdk.git
 cd connect-python-sdk
-if [ `git branch -r | grep "${BRANCH_NAME}"` ]
+
+if [ "${TRAVIS_BRANCH}" = "master" ];
+then
+    BRANCH_NAME=release/$packageVersion
+else
+    BRANCH_NAME=travis-ci/$TRAVIS_BRANCH
+fi
+
+if [ `git branch -r | grep "${BRANCH_NAME}"` ];
 then
     git checkout $BRANCH_NAME
 else
@@ -32,12 +39,5 @@ cp ../swagger-out/python/tox.ini .
 cp ../swagger-out/python/README.md .
 
 git add .
-git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT} | ${TRAVIS_COMMIT_MESSAGE}"
-
-# only push to sdk repo when it's merged into master
-if [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "" -a "${TRAVIS_BRANCH}" = "master" ];
-then
-    git push -u origin $BRANCH_NAME
-else
-    echo "Skip push because of pull request."
-fi
+git commit -m "From connect-api-specification: ${TRAVIS_COMMIT_MESSAGE}"
+git push -u origin $BRANCH_NAME

--- a/travis-ci/push-ruby-sdk.sh
+++ b/travis-ci/push-ruby-sdk.sh
@@ -32,7 +32,7 @@ cp ../swagger-out/ruby/README.md .
 cp ../swagger-out/ruby/square_connect.gemspec .
 
 git add .
-git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT}"
+git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT} | ${TRAVIS_COMMIT_MESSAGE}"
 
 # only push to sdk repo when it's merged into master
 if [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "" -a "${TRAVIS_BRANCH}" = "master" ];

--- a/travis-ci/push-ruby-sdk.sh
+++ b/travis-ci/push-ruby-sdk.sh
@@ -4,7 +4,6 @@ set -e
 
 DIR=$(dirname "$0")
 packageVersion=$( cat ./swagger-config/config-ruby.json | jq -r ".gemVersion" )
-BRANCH_NAME=release/$packageVersion
 
 echo "Going to update Ruby SDK..."
 
@@ -14,7 +13,15 @@ ssh-add $DIR/ruby-repo.pem
 
 git clone git@github.com:square/connect-ruby-sdk.git
 cd connect-ruby-sdk
-if [ `git branch -r | grep "${BRANCH_NAME}"` ]
+
+if [ "${TRAVIS_BRANCH}" = "master" ];
+then
+    BRANCH_NAME=release/$packageVersion
+else
+    BRANCH_NAME=travis-ci/$TRAVIS_BRANCH
+fi
+
+if [ `git branch -r | grep "${BRANCH_NAME}"` ];
 then
     git checkout $BRANCH_NAME
 else
@@ -32,12 +39,5 @@ cp ../swagger-out/ruby/README.md .
 cp ../swagger-out/ruby/square_connect.gemspec .
 
 git add .
-git commit -m "Pushed by Travis CI from connect-api-specification. Commit: ${TRAVIS_COMMIT} | ${TRAVIS_COMMIT_MESSAGE}"
-
-# only push to sdk repo when it's merged into master
-if [ "${TRAVIS_PULL_REQUEST_BRANCH}" = "" -a "${TRAVIS_BRANCH}" = "master" ];
-then
-    git push -u origin $BRANCH_NAME
-else
-    echo "Skip push because of pull request."
-fi
+git commit -m "From connect-api-specification: ${TRAVIS_COMMIT_MESSAGE}"
+git push -u origin $BRANCH_NAME


### PR DESCRIPTION
I'm getting lots of emails that look like `3ee17dc Pushed by Travis CI from connect-api-specification. Commit: 9975b42234ced0699e71ddd4b5da703050c4cb31` And while I could look up what the commit is, it would be nicer if it there was a description of what got added. https://docs.travis-ci.com/user/environment-variables says that the message is unwrapped, and I don't think there is a limit of what you can do with `-m` but there could be issues that I don't see with escaping or something else.  