### PR TITLE
changed license to be more friendly to making gems

### DIFF
--- a/swagger-config/config-ruby.json
+++ b/swagger-config/config-ruby.json
@@ -7,7 +7,7 @@
   "gemAuthorEmail": "developers@squareup.com",
   "gemHomepage": "https://github.com/square/connect-ruby-sdk",
   "gemDescription": "Ruby client library for the Square Connect API",
-  "gemLicense": "Apache 2.0",
+  "gemLicense": "Apache-2.0",
   "gitUserId": "square",
   "gitRepoId": "connect-ruby-sdk"
 }


### PR DESCRIPTION
got this while building the gemfile for ruby: 
```
gem build square_connect.gemspec 
WARNING:  license value 'Apache 2.0' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
```