### PR TITLE
fix incorrect types for v1Item.available_online and v1Variation.ordinal

### DIFF
--- a/api.json
+++ b/api.json
@@ -8934,7 +8934,7 @@
           "description": "The ID of the variation\u0027s associated item."
         },
         "ordinal": {
-          "type": "string",
+          "type": "integer",
           "description": "ndicates the variation\u0027s list position when displayed in Square Register and the merchant dashboard. If more than one variation for the same item has the same ordinal value, those variations are displayed in alphabetical order"
         },
         "pricing_type": {
@@ -9031,7 +9031,7 @@
           "description": "Indicates whether the item is viewable from the merchant\u0027s online store (PUBLIC) or PRIVATE."
         },
         "available_online": {
-          "type": "string",
+          "type": "boolean",
           "description": "If true, the item can be added to shipping orders from the merchant\u0027s online store."
         },
         "master_image": {


### PR DESCRIPTION
This PR fixes 2 incorrect types declared in api.json.

This causes errors in golang when attempting to unmarshal the JSON response into the structs that swagger generates. 
* v1Item.available_online is declared as a string in api.json but the API returns a boolean value.
* v1Variation.ordinal is declared as a string but the API returns an integer.
If I change those 2 fields to the correct values, swagger is able to unmarshal the JSON response successfully.

I imagine that this would impact other language with static typing.