### PR TITLE
Remove hard-coded ?<PARAMETERS> from auth URL

### DIFF
--- a/api.json
+++ b/api.json
@@ -32,7 +32,7 @@
   "securityDefinitions": {
     "oauth2": {
       "type": "oauth2",
-      "authorizationUrl": "https://connect.squareup.com/oauth2/authorize?\u003cPARAMETERS\u003e",
+      "authorizationUrl": "https://connect.squareup.com/oauth2/authorize",
       "flow": "accessCode",
       "tokenUrl": "https://connect.squareup.com/oauth2/token",
       "scopes": {


### PR DESCRIPTION
The authorizationUrl is intended to be used programmatically by Swagger / OpenAPI tooling, which will already know how to append necessary parameters to the the URL. They will not know to remove this hard-coded template.

Spotted by @bobby-brennan in https://github.com/APIs-guru/openapi-directory/pull/241