### PR TITLE
Ruby: remove JSON dep

### DIFF
--- a/swagger-templates/ruby/gemspec.mustache
+++ b/swagger-templates/ruby/gemspec.mustache
@@ -21,13 +21,12 @@ Gem::Specification.new do |s|
   s.license     = "{{{gemLicense}}}"
   {{/gemLicense}}
   {{^gemLicense}}
-  # TODO uncommnet and update below with a proper license 
+  # TODO uncommnet and update below with a proper license
   #s.license     = "Apache 2.0"
   {{/gemLicense}}
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'json', '~> 1.8', '>= 1.8.3'
 
   s.add_development_dependency 'rspec', '~> 3.4', '>= 3.4.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'


### PR DESCRIPTION
fixes https://github.com/square/connect-ruby-sdk/issues/36

JSON is in the standard lib as of ruby 1.9, which this gem requires anyway.

See also https://www.mikeperham.com/2016/02/09/kill-your-dependencies/